### PR TITLE
Feature/async route vaildation

### DIFF
--- a/src/http/nodegen/middleware/asyncValidationMiddleware.ts
+++ b/src/http/nodegen/middleware/asyncValidationMiddleware.ts
@@ -18,7 +18,7 @@ export default (asyncValidators: string[]) => {
       // It is expected the custom async validation method will throw its own http errors
       // @ts-ignore
       if (!AsyncValidationService[methodToCall]) {
-        throw new Error('Unknown async function called: ' + methodToCall);
+        throw new Error(`Unknown AsyncValidationService method function received from the openapi file: ` + methodToCall);
       }
       // @ts-ignore
       await AsyncValidationService[methodToCall](req, asyncValidatorParts);

--- a/src/http/nodegen/middleware/asyncValidationMiddleware.ts
+++ b/src/http/nodegen/middleware/asyncValidationMiddleware.ts
@@ -1,0 +1,14 @@
+import express = require('express');
+
+import NodegenRequest from '../../interfaces/NodegenRequest';
+import AsyncValidationService from '@/services/AsyncValidationService';
+
+/**
+ * Express middleware to control the http headers for caching only
+ * @returns {Function}
+ */
+export default (asyncValidators: string[]) => {
+  return (req: NodegenRequest, res: express.Response, next: express.NextFunction) => {
+    AsyncValidationService.middleware(req, res, next, asyncValidators);
+  };
+}

--- a/src/http/nodegen/middleware/asyncValidationMiddleware.ts
+++ b/src/http/nodegen/middleware/asyncValidationMiddleware.ts
@@ -1,10 +1,12 @@
 import express = require('express');
-
 import NodegenRequest from '../../interfaces/NodegenRequest';
 import AsyncValidationService from '@/services/AsyncValidationService';
 
 /**
- * Express middleware to control the http headers for caching only
+ * Async functions called before hitting a domains layer.
+ * To use, add an x-async-validator attribute to a path object containing
+ * a string[] representing methods from the src/service/AsyncValidationService.ts
+ * The async function will only call next after the async action has completed
  * @returns {Function}
  */
 export default (asyncValidators: string[]) => {

--- a/src/http/nodegen/routes/___op.ts.njk
+++ b/src/http/nodegen/routes/___op.ts.njk
@@ -28,7 +28,7 @@ export default function() {
         {% if securityNames %}accessTokenMiddleware({{ securityNames }}  {% if path['x-passThruWithoutJWT'] %}, {passThruWithoutJWT: true}{% endif %}), /* Validate request security tokens */{% endif %}
         {% if path['x-permission'] %}permissionMiddleware('{{ path['x-permission'] }}'), /* Check permission of the incoming user */ {% endif %}
         {% if pathsHasParamsToValidate(path) %}celebrate({{ _.camelCase(operation_name) }}Validators.{{path.operationId}}), /* Validate the request data and return validation errors */ {% endif %}
-        {% if path['x-async-validator'] %}asyncValidationMiddleware({{ path['x-async-validator'] }}), /* Validate the request data and return validation errors */ {% endif %}
+        {% if path['x-async-validator'] %}asyncValidationMiddleware({{ path['x-async-validator'] | dump }}), /* Validate the request data and return validation errors */ {% endif %}
         {% if path['x-cache'] %}apiCaching({{_.camelCase(operation_name)}}TransformOutputs.{{path.operationId}}), /* Lastly, if x-cache is found, call the api cache middleware */ {% endif %}
         async (req: any, res: express.Response) => {
           {% if not path.produces or path.produces and arrayContains('application/json', path.produces) %}

--- a/src/http/nodegen/routes/___op.ts.njk
+++ b/src/http/nodegen/routes/___op.ts.njk
@@ -6,6 +6,7 @@ import objectReduceByMap from 'object-reduce-by-map'
 {% if pathMethodsHaveAttr(operations, 'security') %}import accessTokenMiddleware from '../middleware/accessTokenMiddleware'{% endif %}
 {% if pathMethodsHaveAttr(operations, 'x-cache') %}import apiCaching from '../middleware/apiCaching'{% endif %}
 {% if pathMethodsHaveAttr(operations, 'x-permission') %}import permissionMiddleware from '../middleware/permissionMiddleware'{% endif %}
+{% if pathMethodsHaveAttr(operations, 'x-async-validator') %}import asyncValidationMiddleware from '../middleware/asyncValidationMiddleware'{% endif %}
 {% if pathMethodsHaveAttr(operations, 'x-worker') %}import WorkerService from '../request-worker/WorkerService'{% endif %}
 import {{ _.camelCase(operation_name) }}Validators from'../validators/{{ prettifyRouteName(operation_name) }}Validators'
 import {{ucFirst(operation_name)}}Domain from '../../../domains/{{ucFirst(operation_name)}}Domain'
@@ -27,6 +28,7 @@ export default function() {
         {% if securityNames %}accessTokenMiddleware({{ securityNames }}  {% if path['x-passThruWithoutJWT'] %}, {passThruWithoutJWT: true}{% endif %}), /* Validate request security tokens */{% endif %}
         {% if path['x-permission'] %}permissionMiddleware('{{ path['x-permission'] }}'), /* Check permission of the incoming user */ {% endif %}
         {% if pathsHasParamsToValidate(path) %}celebrate({{ _.camelCase(operation_name) }}Validators.{{path.operationId}}), /* Validate the request data and return validation errors */ {% endif %}
+        {% if path['x-async-validator'] %}asyncValidationMiddleware({{ path['x-async-validator'] }}), /* Validate the request data and return validation errors */ {% endif %}
         {% if path['x-cache'] %}apiCaching({{_.camelCase(operation_name)}}TransformOutputs.{{path.operationId}}), /* Lastly, if x-cache is found, call the api cache middleware */ {% endif %}
         async (req: any, res: express.Response) => {
           {% if not path.produces or path.produces and arrayContains('application/json', path.produces) %}

--- a/src/http/nodegen/routes/___op.ts.njk
+++ b/src/http/nodegen/routes/___op.ts.njk
@@ -6,7 +6,7 @@ import objectReduceByMap from 'object-reduce-by-map'
 {% if pathMethodsHaveAttr(operations, 'security') %}import accessTokenMiddleware from '../middleware/accessTokenMiddleware'{% endif %}
 {% if pathMethodsHaveAttr(operations, 'x-cache') %}import apiCaching from '../middleware/apiCaching'{% endif %}
 {% if pathMethodsHaveAttr(operations, 'x-permission') %}import permissionMiddleware from '../middleware/permissionMiddleware'{% endif %}
-{% if pathMethodsHaveAttr(operations, 'x-async-validator') %}import asyncValidationMiddleware from '../middleware/asyncValidationMiddleware'{% endif %}
+{% if pathMethodsHaveAttr(operations, 'x-async-validators') %}import asyncValidationMiddleware from '../middleware/asyncValidationMiddleware'{% endif %}
 {% if pathMethodsHaveAttr(operations, 'x-worker') %}import WorkerService from '../request-worker/WorkerService'{% endif %}
 import {{ _.camelCase(operation_name) }}Validators from'../validators/{{ prettifyRouteName(operation_name) }}Validators'
 import {{ucFirst(operation_name)}}Domain from '../../../domains/{{ucFirst(operation_name)}}Domain'
@@ -28,7 +28,7 @@ export default function() {
         {% if securityNames %}accessTokenMiddleware({{ securityNames }}  {% if path['x-passThruWithoutJWT'] %}, {passThruWithoutJWT: true}{% endif %}), /* Validate request security tokens */{% endif %}
         {% if path['x-permission'] %}permissionMiddleware('{{ path['x-permission'] }}'), /* Check permission of the incoming user */ {% endif %}
         {% if pathsHasParamsToValidate(path) %}celebrate({{ _.camelCase(operation_name) }}Validators.{{path.operationId}}), /* Validate the request data and return validation errors */ {% endif %}
-        {% if path['x-async-validator'] %}asyncValidationMiddleware({{ path['x-async-validator'] | dump }}), /* Call an async validator function and throw an appropriate error */ {% endif %}
+        {% if path['x-async-validators'] %}asyncValidationMiddleware({{ path['x-async-validators'] | dump }}), /* Call an async validator function and throw an appropriate error */ {% endif %}
         {% if path['x-cache'] %}apiCaching({{_.camelCase(operation_name)}}TransformOutputs.{{path.operationId}}), /* Lastly, if x-cache is found, call the api cache middleware */ {% endif %}
         async (req: any, res: express.Response) => {
           {% if not path.produces or path.produces and arrayContains('application/json', path.produces) %}

--- a/src/http/nodegen/routes/___op.ts.njk
+++ b/src/http/nodegen/routes/___op.ts.njk
@@ -28,7 +28,7 @@ export default function() {
         {% if securityNames %}accessTokenMiddleware({{ securityNames }}  {% if path['x-passThruWithoutJWT'] %}, {passThruWithoutJWT: true}{% endif %}), /* Validate request security tokens */{% endif %}
         {% if path['x-permission'] %}permissionMiddleware('{{ path['x-permission'] }}'), /* Check permission of the incoming user */ {% endif %}
         {% if pathsHasParamsToValidate(path) %}celebrate({{ _.camelCase(operation_name) }}Validators.{{path.operationId}}), /* Validate the request data and return validation errors */ {% endif %}
-        {% if path['x-async-validator'] %}asyncValidationMiddleware({{ path['x-async-validator'] | dump }}), /* Validate the request data and return validation errors */ {% endif %}
+        {% if path['x-async-validator'] %}asyncValidationMiddleware({{ path['x-async-validator'] | dump }}), /* Call an async validator function and throw an appropriate error */ {% endif %}
         {% if path['x-cache'] %}apiCaching({{_.camelCase(operation_name)}}TransformOutputs.{{path.operationId}}), /* Lastly, if x-cache is found, call the api cache middleware */ {% endif %}
         async (req: any, res: express.Response) => {
           {% if not path.produces or path.produces and arrayContains('application/json', path.produces) %}

--- a/src/services/AsyncValidationService.ts
+++ b/src/services/AsyncValidationService.ts
@@ -1,0 +1,41 @@
+import NodegenRequest from '@/http/interfaces/NodegenRequest';
+import express = require('express');
+
+class AsyncValidationService {
+  /**
+   *
+   * @param req
+   * @param res
+   * @param next
+   * @param asyncValidators
+   */
+  middleware (req: NodegenRequest, res: express.Response, next: express.NextFunction, asyncValidators: string[]) {
+    for (let i = 0; i < asyncValidators.length; ++i) {
+      const asyncValidatorParts = asyncValidators[i].split(':');
+      const methodToCall = String(asyncValidatorParts.shift());
+      // It is expected the custom async validation method will throw its own http errors
+      // @ts-ignore
+      this[methodToCall](req, asyncValidatorParts).then(() => {
+        next();
+      }).catch((e: any) => {
+        throw e;
+      });
+    }
+  }
+
+  /**
+   * EXMAPLE ONLY
+   * @param req
+   * @param asyncValidatorParams
+   */
+  async uniqueUsername (req: NodegenRequest, asyncValidatorParams: string[]): Promise<void> {
+    /**
+     * const user = db.user.find({ username: req.body.username })
+     * if(user){
+     *   throw http422()
+     * }
+     */
+  }
+}
+
+export default new AsyncValidationService();

--- a/src/services/AsyncValidationService.ts
+++ b/src/services/AsyncValidationService.ts
@@ -1,13 +1,9 @@
+import express from 'express';
 import NodegenRequest from '@/http/interfaces/NodegenRequest';
-import express = require('express');
 
 class AsyncValidationService {
   /**
-   *
-   * @param req
-   * @param res
-   * @param next
-   * @param asyncValidators
+   * Entry function for the src/http/nodegen/middleware/asyncValidationMiddleware.ts
    */
   middleware (req: NodegenRequest, res: express.Response, next: express.NextFunction, asyncValidators: string[]) {
     for (let i = 0; i < asyncValidators.length; ++i) {

--- a/src/services/AsyncValidationService.ts
+++ b/src/services/AsyncValidationService.ts
@@ -6,27 +6,31 @@ class AsyncValidationService {
    * Entry function for the src/http/nodegen/middleware/asyncValidationMiddleware.ts
    */
   middleware (req: NodegenRequest, res: express.Response, next: express.NextFunction, asyncValidators: string[]) {
+    this.parseValidators(req, asyncValidators).then(() => {
+      next();
+    }).catch((e) => {
+      throw e;
+    });
+  }
+
+  async parseValidators (req: NodegenRequest, asyncValidators: string[]) {
     for (let i = 0; i < asyncValidators.length; ++i) {
       const asyncValidatorParts = asyncValidators[i].split(':');
-      const methodToCall = String(asyncValidatorParts.shift());
-      // It is expected the custom async validation method will throw its own http errors
+      // Expected the 1st element is the function name followed by params for the given given function
       // @ts-ignore
-      this[methodToCall](req, asyncValidatorParts).then(() => {
-        next();
-      }).catch((e: any) => {
-        throw e;
-      });
+      await this[asyncValidatorParts.shift()](req, asyncValidatorParts);
     }
   }
 
   /**
-   * EXMAPLE ONLY
+   * EXAMPLE ONLY
    * @param req
    * @param asyncValidatorParams
    */
   async uniqueUsername (req: NodegenRequest, asyncValidatorParams: string[]): Promise<void> {
     /**
-     * const user = db.user.find({ username: req.body.username })
+     * // Run the async function and throw the required error when needed
+     * const user = await db.user.find({ username: req.body.username })
      * if(user){
      *   throw http422()
      * }

--- a/src/services/AsyncValidationService.ts
+++ b/src/services/AsyncValidationService.ts
@@ -1,32 +1,6 @@
-import express from 'express';
 import NodegenRequest from '@/http/interfaces/NodegenRequest';
 
 class AsyncValidationService {
-  /**
-   * Entry function for the src/http/nodegen/middleware/asyncValidationMiddleware.ts
-   */
-  middleware (req: NodegenRequest, res: express.Response, next: express.NextFunction, asyncValidators: string[]) {
-    this.parseValidators(req, asyncValidators).then(() => {
-      next();
-    }).catch((e) => {
-      throw next(e);
-    });
-  }
-
-  async parseValidators (req: NodegenRequest, asyncValidators: string[]) {
-    for (let i = 0; i < asyncValidators.length; ++i) {
-      const asyncValidatorParts = asyncValidators[i].split(':');
-      const methodToCall = String(asyncValidatorParts.shift());
-      // It is expected the custom async validation method will throw its own http errors
-      // @ts-ignore
-      if (!this[methodToCall]) {
-        throw new Error('Unknown async function called: ' + methodToCall);
-      }
-      // @ts-ignore
-      await this[methodToCall](req, asyncValidatorParts);
-    }
-  }
-
   /**
    * EXAMPLE ONLY
    * @param req


### PR DESCRIPTION
Using the inject block in boats inject to the required paths the async validator:
```json
{{
  inject([{
    toAllOperations: {
      includeOnlyPaths: [
        '/account/**'
      ],
      content: {
        'x-async-validators': [
          'userOwnsResource',
        ]
      }
    }
  },{...
```
The router will then look like:
```typescript
  router.get(
    '/',
    accessTokenMiddleware([
      'Authorization',
    ]) /* Validate request security tokens */,
    permissionMiddleware(
      'msBusinessAccountMgmt_account_read'
    ) /* Check permission of the incoming user */,
    asyncValidationMiddleware([
      'userOwnsResource',
    ]) /* Call an async validator function and throw an appropriate error */,

    async (req: any, res: express.Response) => {
      return res
        .status(200)
        .json(
          objectReduceByMap(
            await AccountDomain.accountGet(req.jwtData),
            accountTransformOutputs.accountGet
          )
        );
    }
  );
```
The asyncValidationMiddleware then iterates over the given validation functions only calling next if the validator did not throw an error.