### PR TITLE
fix: workers were restarting themselves in a loop

### DIFF
--- a/src/http/nodegen/request-worker/process.ts
+++ b/src/http/nodegen/request-worker/process.ts
@@ -16,10 +16,12 @@ const initStaticPool = () => {
     new Worker(
       `${process.cwd()}/build/src/http/nodegen/request-worker/thread.js`
     )
-      .once('error', () => {
+      .once('error', (e: any) => {
+        console.trace('worker error', e);
         workers[index] = startWorker(index);
       })
-      .once('exit', () => {
+      .once('exit', (e: any) => {
+        console.trace('worker exit', e);
         workers[index] = startWorker(index);
       })
   );

--- a/src/http/nodegen/request-worker/thread.ts
+++ b/src/http/nodegen/request-worker/thread.ts
@@ -1,5 +1,5 @@
 import { parentPort } from 'worker_threads';
-import 'openapi-nodegen-logger';
+import 'generate-it-logger';
 import config from '@/config';
 import requestWorkerThreadLoader from '@/utils/requestWorkerThreadLoader';
 import * as Domains from './domainsImporter';


### PR DESCRIPTION
added worker error logs (likely way too verbose) and fixed error-spawn-error loop

workers were dying immediately (`Error: Cannot find module 'openapi-nodegen-logger'`), then just starting again forever, and never responding to requests.

In addition to fixing that particular error, added very verbose error and exit logging to at least show if this happens again