### PR TITLE
update dockerfile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+{%- set serviceName =  _.kebabCase(package.name) | replace(r/[-_]*swagger$/, "") -%}
 version: "3"
 
 # virtual volume
@@ -5,28 +6,24 @@ volumes:
   build:
 
 services:
-  {{ _.kebabCase(package.name) }}-watcher:
-    image: "${IMAGE_PREFIX}watcher-image:${IMAGE_TAG:-latest}"
-    env_file:
-      - .env
-    depends_on:
-      - {{ _.kebabCase(package.name) }}-service
-    volumes:
-      - .:/code
-      - build:/code/build
-    command: watch
-
-  {{ _.kebabCase(package.name) }}-service:
-    image: "${IMAGE_PREFIX}{{ _.kebabCase(package.name) }}-image:${IMAGE_TAG:-latest}"
-    env_file:
-      - .env
+  {{ serviceName }}:
+    image: "${IMAGE_PREFIX}{{ serviceName }}-image:${IMAGE_TAG:-latest}"
     build:
       dockerfile: Dockerfile
       context: .
-    ports:
-      - "8080:8000"
+    env_file:
+      - .env
     volumes:
       - build:/code/build
-    networks: {{ _.kebabCase(package.name) }}
+      - ./global.d.ts:/code/global.d.ts
+      - ./server.ts:/code/server.ts
+      - ./tsconfig.json:/code/tsconfig.json
+      - ./src:/code/src/
+    ports:
+      - "8080:8000"
+    networks:
+      - {{ serviceName }}
       - default
-    command: dev
+    working_dir: /code
+    entrypoint: /bin/sh
+    command: '-c "npx tsc-watch --preserveWatchOutput --compiler /code/node_modules/.bin/ttsc --onSuccess "/sbin/docker-entrypoint.sh prod""'


### PR DESCRIPTION
could use the same image to build and run the server (tsc-watch), and only mount ts files and src folder for faster builds

also added a service name variable in the tpl so it's easier to read and change, and stripped out the trailing -swagger

closes #31