### PR TITLE
Feat/export swagger baseurl

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -2,8 +2,6 @@ import { requestMiddleware, responseMiddleware } from '@/http/nodegen/middleware
 import routesImporter from '@/http/nodegen/routesImporter';
 import express from 'express';
 
-export const baseUrl = '{{swagger.basePath}}';
-
 /**
  * Returns a promise allowing the server or cli script to know
  * when the app is ready; eg database connections established

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,6 +2,8 @@ import { requestMiddleware, responseMiddleware } from '@/http/nodegen/middleware
 import routesImporter from '@/http/nodegen/routesImporter';
 import express from 'express';
 
+export const baseUrl = '{{swagger.basePath}}';
+
 /**
  * Returns a promise allowing the server or cli script to know
  * when the app is ready; eg database connections established

--- a/src/http/nodegen/routesImporter.ts.njk
+++ b/src/http/nodegen/routesImporter.ts.njk
@@ -1,12 +1,13 @@
-import { baseUrl } from '@/app';
 import config from '@/config';
 import express from 'express';
 {%- for groupName, firstUrlSegment in groupNamesWithFirstUrlSegment %}
 import {{prettifyRouteName(groupName)}}Routes from './routes/{{prettifyRouteName(groupName)}}Routes';
 {%- endfor %}
 
+export const baseUrl = '{{swagger.basePath}}';
+
 export default function (app: express.Application, basePath = baseUrl) {
-  basePath = basePath.replace(/\/+$/, '');
+  basePath = (basePath || '').replace(/\/+$/, '');
 
   {% for groupName, firstUrlSegment in groupNamesWithFirstUrlSegment -%}
   app.use(basePath + '/{{firstUrlSegment}}', {{prettifyRouteName(groupName)}}Routes());

--- a/src/http/nodegen/routesImporter.ts.njk
+++ b/src/http/nodegen/routesImporter.ts.njk
@@ -1,23 +1,19 @@
-import express = require('express')
-import config from '../../config'
-{% for groupName, firstUrlSegment in groupNamesWithFirstUrlSegment -%}
-import {{prettifyRouteName(groupName)}}Routes from './routes/{{prettifyRouteName(groupName)}}Routes'
-{% endfor -%}
+import { baseUrl } from '@/app';
+import config from '@/config';
+import express from 'express';
+{%- for groupName, firstUrlSegment in groupNamesWithFirstUrlSegment %}
+import {{prettifyRouteName(groupName)}}Routes from './routes/{{prettifyRouteName(groupName)}}Routes';
+{%- endfor %}
 
-export default function (app: express.Application, basePath = '') {
+export default function (app: express.Application, basePath = baseUrl) {
+  basePath = basePath.replace(/\/+$/, '');
+
   {% for groupName, firstUrlSegment in groupNamesWithFirstUrlSegment -%}
-    {% if(endsWith(swagger.basePath, '/')) %}
-  app.use(basePath + '{{swagger.basePath}}{{firstUrlSegment}}', {{prettifyRouteName(groupName)}}Routes())
-    {% else %}
-  app.use(basePath + '{{swagger.basePath}}/{{firstUrlSegment}}', {{prettifyRouteName(groupName)}}Routes())
-    {% endif %}
-  {%- endfor %}
+  app.use(basePath + '/{{firstUrlSegment}}', {{prettifyRouteName(groupName)}}Routes());
+
+  {% endfor -%}
 
   if (config.loadSwaggerUIRoute) {
-    {% if(endsWith(swagger.basePath, '/')) %}
-    app.use(basePath + '{{ swagger.basePath }}swagger', require('./routes/swaggerRoutes').default())
-    {% else %}
-    app.use(basePath + '{{ swagger.basePath }}/swagger', require('./routes/swaggerRoutes').default())
-    {% endif %}
+    app.use(basePath + '/swagger', require('./routes/swaggerRoutes').default());
   }
 }


### PR DESCRIPTION
Add swagger baseUrl to app.ts exports.

Pass it into routes imported by default, fix up the pathing.

Allows for importing baseUrl in tests.

for a test project, output looks like this
```typescript
import { baseUrl } from '@/app';
import config from '@/config';
import express from 'express';
import adminRoutes from './routes/adminRoutes';
import rolesRoutes from './routes/rolesRoutes';
import usersRoutes from './routes/usersRoutes';

export default function (app: express.Application, basePath = baseUrl) {
  basePath = basePath.replace(/\/+$/, '');

  app.use(basePath + '/admin', adminRoutes());

  app.use(basePath + '/roles', rolesRoutes());

  app.use(basePath + '/users', usersRoutes());

  if (config.loadSwaggerUIRoute) {
    app.use(basePath + '/swagger', require('./routes/swaggerRoutes').default());
  }
}
```