### PR TITLE
Ignore built files in jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -27,6 +27,11 @@ module.exports = {
     '/build/',
     '/dist/',
   ],
+  modulePathIgnorePatterns: [
+    '/node_modules/',
+    '/build/',
+    '/dist/',
+  ],
   testEnvironment: 'node',
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',


### PR DESCRIPTION
- add module ignore to jest config

When running tests, jest-haste-map will print out warnings about duplicate mocks / naming collisions

```

... many more ...

jest-haste-map: duplicate manual mock found: SomethingMock
  The following files share their name; please delete one of them:
    * <rootDir>/build/src/domains/__mocks__/SomethingMock.js
    * <rootDir>/src/domains/__mocks__/SomethingMock.ts

jest-haste-map: Haste module naming collision: your-package-name
  The following files share their name; please adjust your hasteImpl:
    * <rootDir>/build/package.json
    * <rootDir>/package.json
```

