### PR TITLE
Replace pre-rebase with pre-push hook, which runs tests

### DIFF
--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -2,4 +2,4 @@
 
 # Run all tests before rebasing
 npm run lint || exit 1
-npm run test || exit 1
+npm run test -- --passWithNoTests || exit 1


### PR DESCRIPTION
Trying to enforce more testing done locally - it's far too much to do it on pre-commit, so pre-push seems reasonable.

Added 755 mode to hooks (enable both by default if `dev:setup` is run).