### PR TITLE
Fix: content-negotiation

### DIFF
--- a/src/http/nodegen/interfaces/GenerateItExpressResponse.ts
+++ b/src/http/nodegen/interfaces/GenerateItExpressResponse.ts
@@ -5,7 +5,7 @@ export default interface GenerateItExpressResponse extends express.Response {
   inferResponseType: (
     dataOrPath: any,
     status: number,
-    permittedTypes: string | string[],
-    outputMap?: any
+    produces: string,
+    outputMap?: Record<string, any>
   ) => any
 }

--- a/src/http/nodegen/middleware/inferResponseType.ts
+++ b/src/http/nodegen/middleware/inferResponseType.ts
@@ -1,83 +1,55 @@
+import NodegenRequest from '@/http/interfaces/NodegenRequest';
+import { NotAcceptableException } from '@/http/nodegen/errors';
+import GenerateItExpressResponse from '@/http/nodegen/interfaces/GenerateItExpressResponse';
+import getPreferredResponseFormat from '@/http/nodegen/utils/getPreferredResponseFormat';
 import express from 'express';
 import objectReduceByMap from 'object-reduce-by-map';
-import NodegenRequest from '@/http/interfaces/NodegenRequest';
-import getPreferredResponseFormat from '@/http/nodegen/utils/getPreferredResponseFormat';
-import GenerateItExpressResponse from '@/http/nodegen/interfaces/GenerateItExpressResponse';
 
 export default () => {
-
   return (req: NodegenRequest, res: GenerateItExpressResponse, next: express.NextFunction) => {
-
     res.inferResponseType = (
       dataOrPath = undefined,
       status = 200,
-      permittedTypes,
-      outputMap?
+      produces?: string,
+      outputMap?: Record<string, any>
     ) => {
       // Send only a status when data is undefined
       if (dataOrPath === undefined) {
         return res.sendStatus(status);
       }
 
-      permittedTypes = Array.isArray(permittedTypes) ? permittedTypes : [permittedTypes];
+      const accept = req.headers['accept'] || '*/*';
+      let possibleResponseTypes: string[] = produces ? [...produces.split(',')] : ['application/json'];
 
-      // Calculate the calculatedAcceptHeader based on the provided accept header
-      // When the accept header is not provided then we fallback to the 1st permittedType
-      // The last fallback is then application/json
-      const calculatedContentType = req.headers['accept'] ?
-        getPreferredResponseFormat(req.headers['accept'], permittedTypes) :
-        permittedTypes.length > 0 ? permittedTypes[0] : 'application/json';
+      // Calculate the responseContentType based on the provided accept header
+      let responseContentType = getPreferredResponseFormat(accept, possibleResponseTypes);
 
-      if (calculatedContentType) {
-        // The most typical is json so lets catch it 1st
-        if (calculatedContentType === 'application/json') {
-          return res
-            .status(status)
-            .json(
-              objectReduceByMap(
-                dataOrPath,
-                outputMap
-              )
-            );
-        }
-
-        // All images use with sendFile
-        if (calculatedContentType.includes('image/') || calculatedContentType.includes('font/')) {
-          return res.sendFile(dataOrPath);
-        }
-
-        // Simple pass for text/* let the consumer handle the rest
-        if (calculatedContentType.includes('text/')) {
-          return res
-            .set('Content-Type', calculatedContentType)
-            .status(status)
-            .send(dataOrPath);
-        }
-
-        // Everything else we assume the input is a path to a file and should be downloaded
-        // XML is typically sent not downloaded but fairly outdated today so the converter js2xmlparser
-        // is not included
-        return res.download(dataOrPath);
-
-      } else if (req.headers['accept'] && !calculatedContentType) {
-        console.error(`Accept Header ${req.headers['accept']} requested but not permitted`);
-        return res
-          .status(406)
-          .send(`Requested content-type "${req.headers['accept']}", only ${JSON.stringify(permittedTypes)} permitted for this route.`);
+      if (!responseContentType) {
+        console.error(`Requested content-type "${accept}" not supported`);
+        throw new NotAcceptableException(`Requested content-type "${accept}" not supported`);
       }
 
-      // default catch all is json
-      // We got here by not defining response content types in the openapi file
-      return res
-        .status(status)
-        .json(
-          objectReduceByMap(
-            dataOrPath,
-            outputMap
-          )
-        );
+      // No "produces" in the openapi file
+      if (responseContentType === 'application/json') {
+        return res.status(status).json(objectReduceByMap(dataOrPath, outputMap));
+      }
+
+      // All images use with sendFile
+      if (responseContentType.startsWith('image/') || responseContentType.startsWith('font/')) {
+        return res.sendFile(dataOrPath);
+      }
+
+      // Simple pass for text/* let the consumer handle the rest
+      if (responseContentType.startsWith('text/')) {
+        return res.set('Content-Type', responseContentType).status(status).send(dataOrPath);
+      }
+
+      // Everything else we assume the input is a path to a file and should be downloaded
+      // XML is typically sent not downloaded but fairly outdated today so the converter js2xmlparser
+      // is not included
+      return res.download(dataOrPath);
     };
 
     next();
   };
-}
+};

--- a/src/http/nodegen/middleware/inferResponseType.ts
+++ b/src/http/nodegen/middleware/inferResponseType.ts
@@ -29,7 +29,9 @@ export default () => {
         throw new NotAcceptableException(`Requested content-type "${accept}" not supported`);
       }
 
-      // No "produces" in the openapi file
+      res.set('Content-Type', responseContentType);
+
+      // No "produces", or json in the openapi file
       if (responseContentType === 'application/json') {
         return res.status(status).json(objectReduceByMap(dataOrPath, outputMap));
       }
@@ -41,7 +43,7 @@ export default () => {
 
       // Simple pass for text/* let the consumer handle the rest
       if (responseContentType.startsWith('text/')) {
-        return res.set('Content-Type', responseContentType).status(status).send(dataOrPath);
+        return res.status(status).send(dataOrPath);
       }
 
       // Everything else we assume the input is a path to a file and should be downloaded

--- a/src/http/nodegen/utils/getPreferredResponseFormat.ts
+++ b/src/http/nodegen/utils/getPreferredResponseFormat.ts
@@ -2,16 +2,18 @@
  * Figure out which response type to send based on accept header
  * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept
  *
- * @param  {string}  acceptHeaderValue  The accept header
- * @param  {array}   mimes   Our desired response types (in order as defined in the openapi file)
+ * @param  {string}  accept       The accept header
+ * @param  {array}   mimes        Our desired response types (in order as defined in the openapi file)
  *
- * @return {string | undefined}  If the accept header contains something we would like to
- *                   send, it will be returned, else undefined.
+ * @return {string | undefined}   If the accept header contains something we would like to
+ *                                send, it will be returned, else undefined.
  */
-export default (acceptHeaderValue: string, mimes: string[]): string => {
-  mimes = Object.assign([], mimes);
+export default (accept: string, mimes: string[]): string => {
+  if (!accept || !mimes?.length) {
+    throw new Error('Should not be hit');
+  }
 
-  const priority: string[][] = acceptHeaderValue.split(/\s*,\s*/).reduce((acc, val) => {
+  const priority: string[][] = accept.split(/\s*,\s*/).reduce((acc, val) => {
     const [mime, prio] = val.split(';');
     const prioValue = (prio || '1').replace(/.*=\s*/, '');
     const index = 10 - Math.round(parseFloat(prioValue) * 10);
@@ -20,21 +22,32 @@ export default (acceptHeaderValue: string, mimes: string[]): string => {
     return acc;
   }, []);
 
-  mimes.unshift('*/*');
-
-  const parts = mimes.map(mime => {
+  const parts = [...mimes, '*/*'].reduce((acc, mime) => {
+    if (!mime) {
+      return acc;
+    }
     const [type, subtype] = mime.split('/');
     if (!subtype) {
-      return type.replace(/\*/g, '\\*');
+      return acc.concat(type.replace(/\*/g, '\\*'));
     }
 
-    return `${type}\/(${subtype}|*)`.replace(/\*/g, '\\*');
-  });
+    return acc.concat(`${type}\/(${subtype}|*)`.replace(/\*/g, '\\*'));
+  }, []);
 
   const willAccept = new RegExp(parts.join('|'));
-  const preference = priority.find(mimeTypes => mimeTypes.find(mime => willAccept.test(mime)));
+  const matchingAccept = priority.find((mimeTypes) => mimeTypes.find((mime) => willAccept.test(mime)))?.[0];
 
-  return preference ?
-    preference[0] === '*/*' ? mimes[1] : preference[0] :
-    undefined;
-}
+  let matchRegex: string | RegExp = 'NOPE';
+
+  if (matchingAccept) {
+    matchRegex = new RegExp(matchingAccept.replace(/\*/g, '[^/]*'));
+  }
+
+  if (!matchingAccept) {
+    return;
+  }
+
+  const contentType = mimes.find((mime) => (matchRegex as RegExp).test(mime));
+
+  return contentType;
+};

--- a/src/http/nodegen/utils/getPreferredResponseFormat.ts
+++ b/src/http/nodegen/utils/getPreferredResponseFormat.ts
@@ -37,17 +37,11 @@ export default (accept: string, mimes: string[]): string => {
   const willAccept = new RegExp(parts.join('|'));
   const matchingAccept = priority.find((mimeTypes) => mimeTypes.find((mime) => willAccept.test(mime)))?.[0];
 
-  let matchRegex: string | RegExp = 'NOPE';
-
-  if (matchingAccept) {
-    matchRegex = new RegExp(matchingAccept.replace(/\*/g, '[^/]*'));
-  }
-
   if (!matchingAccept) {
     return;
   }
 
-  const contentType = mimes.find((mime) => (matchRegex as RegExp).test(mime));
+  const matchRegex = new RegExp(matchingAccept.replace(/\*/g, '[^/]*'));
 
-  return contentType;
+  return mimes.find((mime) => matchRegex.test(mime));
 };


### PR DESCRIPTION
Should resolve all use-cases of content negotiation.

With no accept header, `*/*` is assumed, and with no produces in the open api spec, `application/json` is assumed.

Knowing that, we can parse and prioritize the accept header and find which content-type in our possible return types matches those.

This does not validate the accept header or the produces values, so it's possible that invalid values could break the whole thing, but it appears to handle everything else