### PR TITLE
Exit on entrypoint error

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+# if any errors occur, abort with erorr code
+# this will prevent restart loops if any command fails
+set -e
+
 echo "Command: $@"
 
 command="${1:-prod}"


### PR DESCRIPTION
We had the issue where migrations (run before npm start) were failing, but the app continued away, failing to start, dying, then rinse and repeat.

If any command fails in the startup script, it should immediately bail