### PR TITLE
Fix/ignore charset safely

### DIFF
--- a/src/http/nodegen/middleware/inferResponseType.ts.njk
+++ b/src/http/nodegen/middleware/inferResponseType.ts.njk
@@ -9,7 +9,7 @@ export default () => {
   return (req: NodegenRequest, res: GenerateItExpressResponse, next: express.NextFunction) => {
     const apiProduces = '{{ swagger.produces }}'
       .split(',')
-      .map((s: string) => s.replace(/;.*/, '').trim());
+      .reduce((a: string[], s: string) => a.concat(s, s.replace(/;.*/, '').trim()), []);
 
     res.inferResponseType = (
       dataOrPath = undefined,

--- a/src/http/nodegen/utils/getPreferredResponseFormat.ts
+++ b/src/http/nodegen/utils/getPreferredResponseFormat.ts
@@ -22,7 +22,7 @@ export default (accept: string, mimes: string[]): string => {
     // extension might look like { q: '0.1', charset: 'utf-8' }
     // https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.1
     const extension = extra.reduce((acc: Record<string, string>, val) => {
-      const [key, value] = val.split(/\s*=\s*/);
+      const [key, value] = val.split('=').map(s => s.trim());
       acc[key] = value;
 
       return acc;

--- a/src/http/nodegen/utils/getPreferredResponseFormat.ts
+++ b/src/http/nodegen/utils/getPreferredResponseFormat.ts
@@ -10,7 +10,7 @@
  */
 export default (accept: string, mimes: string[]): string => {
   if (!accept || !mimes?.length) {
-    throw new Error('Should not be hit');
+    return null;
   }
 
   // escape all special chars except *

--- a/src/http/nodegen/utils/getPreferredResponseFormat.ts
+++ b/src/http/nodegen/utils/getPreferredResponseFormat.ts
@@ -22,7 +22,7 @@ export default (accept: string, mimes: string[]): string => {
     // extension might look like { q: '0.1', charset: 'utf-8' }
     // https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.1
     const extension = extra.reduce((acc: Record<string, string>, val) => {
-      const [key, value] = val.split('=').map(s => s.trim());
+      const [key, value] = val.split(/\s*=\s*/);
       acc[key] = value;
 
       return acc;

--- a/src/http/nodegen/utils/getPreferredResponseFormat.ts
+++ b/src/http/nodegen/utils/getPreferredResponseFormat.ts
@@ -17,8 +17,18 @@ export default (accept: string, mimes: string[]): string => {
   const formatRegex = (s: string) => s.replace(/[.+?^${}()|[\]\\]/g, '\\$&')
 
   const priority: string[][] = accept.split(/\s*,\s*/).reduce((acc, val) => {
-    const [mime, prio] = val.split(';');
-    const prioValue = (prio || '1').replace(/.*=\s*/, '');
+    const [mime, ...extra] = val.split(';');
+
+    // extension might look like { q: '0.1', charset: 'utf-8' }
+    // https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.1
+    const extension = extra.reduce((acc: Record<string, string>, val) => {
+      const [key, value] = val.split('=').map(s => s.trim());
+      acc[key] = value;
+
+      return acc;
+    }, {});
+
+    const prioValue = (extension.p || '1').replace(/.*=\s*/, '');
     const index = 10 - Math.round(parseFloat(prioValue) * 10);
     acc[index] = (acc[index] || []).concat(mime);
 


### PR DESCRIPTION
Server was falling over when the client sent `application/json; charset=utf-8`

[Apparently](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.1) something like 
`Accept: application/json; charset=utf-8; q=0.2, tex/plain` 
is valid, so instead of blindly splitting on semicolon we just map key=value pairs, and ignore most of them.