### PR TITLE
ignore 40 line limit in spec files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,4 +45,12 @@ module.exports = {
       { vars: 'all', args: 'none', ignoreRestSiblings: false },
     ],
   },
+  overrides: [
+    {
+      files: ['**/*.spec.ts'],
+      rules: {
+        'max-lines-per-function': 'off',
+      },
+    },
+  ],
 };


### PR DESCRIPTION
default lint to ignore long functions in spec files