### PR TITLE
Add orbm nullish keys

### DIFF
--- a/.nodegenrc
+++ b/.nodegenrc
@@ -12,7 +12,8 @@
     "objectReduceByMapOptions": {
       "allowNullish": false,
       "keepKeys": false,
-      "throwErrorOnAlien": false
+      "throwErrorOnAlien": false,
+      "allowNullishKeys": false
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lodash": "^4.17.20",
     "morgan": "^1.10.0",
     "node-worker-threads-pool": "^1.4.3",
-    "object-reduce-by-map": "^2.0.0",
+    "object-reduce-by-map": "^2.0.2",
     "openapi-nodegen-config-helper": "^1.3.1",
     "recursive-readdir-sync": "^1.0.6",
     "request-ip": "^2.1.3",


### PR DESCRIPTION
Add default settings to object-reduce-by-map in nodegenrc

Assuming this goes through:
https://github.com/johndcarmichael/object-reduce-by-map/pull/12