### PR TITLE
properly parse optional outDir param

### DIFF
--- a/src/http/nodegen/tests/___eval.ts
+++ b/src/http/nodegen/tests/___eval.ts
@@ -378,7 +378,7 @@ ${toExport?.length ? toExport.join('\n\n') : ''}
 `;
 
 const generateTestStub = (basePath: string, domainSpec: DomainSpec, tests: string[], useAuth?: boolean): boolean => {
-  basePath = (basePath || 'src/domains/__tests__').replace(/\/|$/, '');
+  basePath = (basePath || 'src/domains/__tests__').replace(/\/+$/, '');
 
   const outputPath = `${basePath}/${domainSpec.domainName}.api.spec.ts`;
   if (fs.existsSync(outputPath)) {
@@ -487,7 +487,7 @@ const buildSpecFiles = (ctx: Context): void => {
       `${ctx.dest}/${specFileName}.ts`,
       generateTestFile(domainSpec.domainName, dataTemplates, importString)
     );
-    generateTestStub(ctx.nodegenRc?.helpers?.tests.outDir, domainSpec, stubTemplates, useAuth);
+    generateTestStub(ctx.nodegenRc?.helpers?.tests?.outDir, domainSpec, stubTemplates, useAuth);
   });
 
   createFormattedFile(`${ctx.dest}/index.ts`, generateIndexFile(indexImports, indexExports));


### PR DESCRIPTION
nodegenrc params were not being parsed properly

these formats are accepted and properly parsed:
```json
{
  "helpers": {
    "tests": true
  }
}
```
```json
{
  "helpers": {
    "tests": {
      "outDir": "test/"
    }
  }
}
```
```json
{
  "helpers": {
    "tests": {
      "outDir": "src/domains/spectacular"
    }
  }
}
```