### PR TITLE
fix: allow async auth middleware

### DIFF
--- a/src/http/nodegen/tests/___eval.ts
+++ b/src/http/nodegen/tests/___eval.ts
@@ -461,6 +461,8 @@ export const defaultSetupTeardown = () => {
   afterAll(setupTeardown.afterAll);
 };
 
+export type Async<T> = T extends (... args: infer T) => infer T ? Promise<T> : never;
+
 /**
  * Auth middleware mocker
  *
@@ -471,7 +473,7 @@ export const defaultSetupTeardown = () => {
  *
  * @param {RequestHandler}  middleware  Replaces AccessTokenService.validateRequest
  */
-export const mockAuth = (middleware?: RequestHandler) => {
+export const mockAuth = (middleware?: Async<RequestHandler>) => {
   jest
     .spyOn(AccessTokenService, 'validateRequest')
     .mockImplementation(

--- a/src/http/nodegen/tests/___eval.ts
+++ b/src/http/nodegen/tests/___eval.ts
@@ -461,7 +461,7 @@ export const defaultSetupTeardown = () => {
   afterAll(setupTeardown.afterAll);
 };
 
-export type Async<T> = T extends (... args: infer T) => infer T ? Promise<T> : never;
+export type Async<T> = T extends (...args: infer T) => infer T ? Promise<T> : never;
 
 /**
  * Auth middleware mocker


### PR DESCRIPTION
use async middleware by default - might mean extra `Promise.resolve` in places, but necessary in order to use async validation