### PR TITLE
Hotfix/dont format index file

### DIFF
--- a/src/http/nodegen/tests/___eval.ts
+++ b/src/http/nodegen/tests/___eval.ts
@@ -461,6 +461,8 @@ export const defaultSetupTeardown = () => {
   afterAll(setupTeardown.afterAll);
 };
 
+export type Async<T> = T extends (...args: infer T) => infer T ? Promise<T> : never;
+
 /**
  * Auth middleware mocker
  *
@@ -471,7 +473,7 @@ export const defaultSetupTeardown = () => {
  *
  * @param {RequestHandler}  middleware  Replaces AccessTokenService.validateRequest
  */
-export const mockAuth = (middleware?: RequestHandler) => {
+ export const mockAuth = (middleware?: Async<RequestHandler>) => {
   jest
     .spyOn(AccessTokenService, 'validateRequest')
     .mockImplementation(

--- a/src/http/nodegen/tests/___eval.ts
+++ b/src/http/nodegen/tests/___eval.ts
@@ -607,7 +607,7 @@ const buildSpecFiles = (ctx: Context): void => {
     generateTestStub(testOutput, domainSpec, stubTemplates, useAuth);
   });
 
-  createFormattedFile(`${ctx.dest}/index.ts`, generateIndexFile(indexImports, indexExports));
+  fs.writeFileSync(`${ctx.dest}/index.ts`, generateIndexFile(indexImports, indexExports));
 };
 
 export default buildSpecFiles;


### PR DESCRIPTION
babel parser is failing (used by prettier) so just ignore it for now. if a fix is pushed then we can format again

tried updating prettier and @babel/parser - neither solved the issue

for reference:
![image](https://user-images.githubusercontent.com/8646562/108989168-995ac700-7695-11eb-8188-2a0af1f2eaeb.png)
